### PR TITLE
Splint adjustment

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -969,6 +969,8 @@
 				. *= 1.25
 			if(SANITY_NEUTRAL to INFINITY)
 				. *= 0.90
+	if(broken_hands > 0)
+		. *= ((broken_hands / 4) + 1) //.25 penalty per broken or splinted hand
 
 /mob/living/carbon/proc/create_internal_organs()
 	for(var/X in internal_organs)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1788,6 +1788,11 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('icons/mob/ssd_indicat
 	else if(!(movement_type & (FLYING | FLOATING)) && !usable_hands && !usable_legs) //Lost a hand, not flying, no hands left, no legs.
 		ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
+/mob/living/proc/set_broken_hands(new_value) //Used for adjusting do_after_coefficient
+	if(broken_hands == new_value)
+		return
+	. = broken_hands
+	broken_hands = new_value
 
 /// Changes the value of the [living/body_position] variable.
 /mob/living/proc/set_body_position(new_value, fall_sound_played)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -104,6 +104,8 @@
 	var/num_hands = 2
 	///How many usable hands does this mob currently have. Should only be changed through set_usable_hands()
 	var/usable_hands = 2
+	///How many broken hands does this mob currently have. Should only be changed through set_usable_hands()
+	var/broken_hands = 0
 
 	var/list/pipes_shown = list()
 	var/last_played_vent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
hey check it out I'm PRing your fork.
Adds some of the splint changes discussed in #development-general, mainly:

- Broken and splinted arms add a stacking 25% do_after penalty
- Splinted bodyparts have halved break_threshold and double break_modifier

This aims to make splints a meaningful half-measure until surgery rather than a weird alternative to surgery (did you know that only splinted legs had a meaningful debuff?)
